### PR TITLE
fix(EditUserForm): Create new user when editing

### DIFF
--- a/src/app/components/edit-user/EditUserForm.tsx
+++ b/src/app/components/edit-user/EditUserForm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { IUser } from '../../../api/types';
+import { User } from '../../../api/user';
 import { FormGroup, Label, Input, Button, InputReadonly } from '../../../ui';
 import { SubmitHandler } from '../types';
 
@@ -21,7 +22,9 @@ export const EditUserForm: React.FC<EditUserFormProps> = ({
           <Input
             value={editUser.name}
             onChange={(ev) => {
-              setEditUser({ ...editUser, name: ev.target.value });
+              setEditUser(
+                new User({ ...editUser.toJson(), name: ev.target.value })
+              );
             }}
           />
         </FormGroup>


### PR DESCRIPTION
This fixes faulty binding of the `this` keyword, which would continue to point to the old value after editing. Was leading to faulty values when calling `editedUser.toJson()`.